### PR TITLE
"Fix" for Widget 3

### DIFF
--- a/nspanel.be
+++ b/nspanel.be
@@ -310,7 +310,13 @@ class NSPanel : Driver
             msg = msg[5..j]
               if size(msg) > 2
                 if msg == bytes('7B226572726F72223A307D') # don't publish {"error":0}
-                else 
+                else
+                print(msg)
+                if msg == bytes('7B226964223A2233227D7D')
+                  msg = bytes('7B226964223A2233227D')
+                  print("bamboozled")
+                end
+                print(msg) 
                 var jm = string.format("{\"NSPanel\":%s}",msg.asstring())
                 tasmota.publish_result(jm, "RESULT")
                 end


### PR DESCRIPTION
So I found a weird bug while testing widgets, especially scenes.

If I set the index 3 widget as a scene the MQTT output has an additional brace at the end breaking the parsing.

Console output:

`23:28:57.903 NSP: Received Raw = bytes('55AA860A007B226964223A2233227D7DAF00')`
`23:28:57.915 bytes('7B226964223A2233227D7D')`
`23:28:57.931 MQT: tele/NSPanel/RESULT = {"NSPanel":{"id":"3"}}}`

I'm not that skilled and I don't think my attempt is a valid fix. But issues are not enabled here for good I guess.