### PR TITLE
Added missing value 248 fog for wttr weatherCode lookup

### DIFF
--- a/nspanel.be
+++ b/nspanel.be
@@ -210,6 +210,7 @@ class NSPanel : Driver
         "200": 42,   # ThunderyShowers  
         "227": 20,   # LightSnow  
         "230": 22,   # HeavySnow        
+        "248": 11,   # Fog                 
         "260": 11,   # Fog                 
         "263": 40,   # LightShowers     
         "266": 40,   # LightRain      


### PR DESCRIPTION
The value 248 was missing in the lookup generating an exception (weather was indeed foggy). 
Source https://github.com/chubin/wttr.in/blob/master/lib/constants.py