### PR TITLE
Fix end of payload.

### DIFF
--- a/nspanel.be
+++ b/nspanel.be
@@ -303,12 +303,7 @@ class NSPanel : Driver
                 if msg[2] == 0x84 self.ser.write(msg)   # resend messages with type 0x84 for thermostat page
                 end
               end
-            var j = size(msg) - 1
-            while msg[j] != 0x7D
-              msg = msg[0..-1]
-              j -= 1
-            end        
-            msg = msg[5..j]
+            msg = msg[5..-4]
               if size(msg) > 2
                 if msg == bytes('7B226572726F72223A307D') # don't publish {"error":0}
                 else 


### PR DESCRIPTION
The detection of the end of the payload is wrong. There are 3 bytes after the payload. What the current implementation does it searching from the end backwards for the '}' character. I _assume_ that these 3 extra bytes contain a checksum of some sort since the data can be any value. If one of those 3 bytes happen to be 0x125 which is the same as the '}' character, the detection is wrong and you end up with payloads like {"id":"3"}}   or {"id":"4"}B} which are obviously not the correct payloads.