### PR TITLE
Fix index_error in split_55 function

### DIFF
--- a/nspanel.be
+++ b/nspanel.be
@@ -112,7 +112,7 @@ class NSPanel : Driver
   def split_55(b)
     var ret = []
     var s = size(b)   
-    var i = s-1   # start from last
+    var i = s-2   # start from last-1
     while i > 0
       if b[i] == 0x55 && b[i+1] == 0xAA           
         ret.push(b[i..s-1]) # push last msg to list


### PR DESCRIPTION
There is an index_error in the split_55 function that occurs in case the received message end's with 0x55, because
`    if b[i] == 0x55 && b[i+1] == 0xAA           ` 
tries to access b[i+1].
 
See the following example to reproduce the error (test1 fails, test2 works):
 
```
test1 = bytes('55BB106576656E742C706167654F70656E2C345355')
test2 = bytes('55bb106576656e742c706167654f70656e2c331297')

def split_55(b)
  var ret = []
  var s = size(b)   
  var i = s-1   # start from last
  while i > 0
    if b[i] == 0x55 && b[i+1] == 0xBB           
      ret.push(b[i..s-1]) # push last msg to list
      b = b[(0..i-1)]   # write the rest back to b
    end
    i -= 1
  end
  ret.push(b)
  return ret
end

split_55(test1)
```

Ignore the different Header in the example, bug should still apply.

Came accross this by accident in my project.

joBr99/nspanel-lovelance-ui#11

Changeing the start point to s-2 should fix the issue, however in case the checksum is 55AA the behaviour might be still strange, didn't check  ... but two matching byte that should be way less likely than one matching byte.